### PR TITLE
Fixing PageSpeed Minimal Beacon 'err' and 'na' values - HTTP 400 Error

### DIFF
--- a/beacon/pagespeed/index.php
+++ b/beacon/pagespeed/index.php
@@ -253,8 +253,6 @@ if (array_key_exists('u', $_GET)) {
 			&& ($core_metrics['w'] = filter_var($_GET['w'], FILTER_VALIDATE_INT)) !== false
 		&& array_key_exists('o', $_GET)
 			&& ($core_metrics['o'] = filter_var($_GET['o'], FILTER_VALIDATE_FLOAT)) !== false
-		&& array_key_exists('l', $_GET)
-			&& ($core_metrics['l'] = filter_var($_GET['l'], FILTER_VALIDATE_INT)) !== false
 		&& array_key_exists('r', $_GET)
 			&& ($core_metrics['r'] = filter_var($_GET['r'], FILTER_VALIDATE_INT)) !== false
 		&& array_key_exists('t', $_GET)


### PR DESCRIPTION
In regards to this issue [https://github.com/sergeychernyshev/showslow/issues/88]

Unlike the presented approach of replacing the values, I simply removed the integer validation. This is more efficient since the value is hardcoded to "0" for now anyways on line 206.
