### PR TITLE
phantomjs automated yslow monitoring - fix args

### DIFF
--- a/automation/phantomjs/monitor.sh
+++ b/automation/phantomjs/monitor.sh
@@ -12,6 +12,6 @@ YSLOWJS='... path to yslow.js ...'
 
 for URL in $URLS
 do
-	echo "$URL" | $PHANTOMJS $YSLOWJS -i grade -b $SHOWSLOWBASE/beacon/yslow/ >/dev/null
+	$PHANTOMJS $YSLOWJS -i grade -b $SHOWSLOWBASE/beacon/yslow/ $URL >/dev/null
 done
 


### PR DESCRIPTION
Seems that recent versions of yslow-phantomjs want the URL as argument instead of stdin.

```
ubuntu@ip-10-194-173-97:/var/www/showslow$ $PHANTOMJS /home/ubuntu/code/yslow/yslow.js -V
3.1.1

ubuntu@ip-10-194-173-97:/var/www/showslow$ echo http://showslow.com | $PHANTOMJS /home/ubuntu/code/yslow/yslow.js -i grade -f plain

  Usage: phantomjs [phantomjs options] yslow.js [yslow options] [url ...]

  PhantomJS Options:

    http://y.ahoo.it/phantomjs/options

  YSlow Options:

    -h, --help               output usage information
    -V, --version            output the version number
    -i, --info <info>        specify the information to display/log (basic|grade|stats|comps|all) [all]
    -f, --format <format>    specify the output results format (json|xml|plain|tap|junit) [json]
    -r, --ruleset <ruleset>  specify the YSlow performance ruleset to be used (ydefault|yslow1|yblog) [ydefault]
    -b, --beacon <url>       specify an URL to log the results
    -d, --dict               include dictionary of results fields
    -v, --verbose            output beacon response information
    -t, --threshold <score>  for test formats, the threshold to test scores ([0-100]|[A-F]|{JSON}) [80]
                             e.g.: -t B or -t 75 or -t '{"overall": "B", "ycdn": "F", "yexpires": 85}'
    -u, --ua "<user agent>"  specify the user agent string sent to server when the page requests resources
    -vp, --viewport <WxH>    specify page viewport size WxY, where W = width and H = height [400x300]
    -ch, --headers <JSON>    specify custom request headers, e.g.: -ch '{"Cookie": "foo=bar"}'
    -c, --console <level>    output page console messages (0: none, 1: message, 2: message + line + source) [0]

  Examples:

    phantomjs yslow.js http://yslow.org
    phantomjs yslow.js -i grade -f xml www.yahoo.com www.cnn.com www.nytimes.com
    phantomjs yslow.js -info all --format plain --ua "MSIE 9.0" http://yslow.org
    phantomjs yslow.js -i basic --rulseset yslow1 -d http://yslow.org
    phantomjs yslow.js -i grade -b http://www.showslow.com/beacon/yslow/ -v yslow.org
    phantomjs --load-plugins=yes yslow.js -vp 800x600 http://www.yahoo.com
    phantomjs yslow.js -i grade -f tap -t 85 http://yslow.org

ubuntu@ip-10-194-173-97:/var/www/showslow$ $PHANTOMJS /home/ubuntu/code/yslow/yslow.js -i grade -f plain http://showslow.com
size: 471.7K (471758 bytes)
overall score: B (85)
url: http://www.showslow.com/
# of requests: 20
ruleset: ydefault
...
```
