### PR TITLE
PageSpeed Insights: Use ruleImpact if ruleScore is not available

### DIFF
--- a/beacon/pagespeed/index.php
+++ b/beacon/pagespeed/index.php
@@ -222,8 +222,12 @@ if (array_key_exists('u', $_GET)) {
 			$metric = $rule_metric_map[$rule];
 
 			if (!array_key_exists('ruleScore', $data)) {
-				error_log('Rule score is not specified: '.$rule.' (skipping)');
-				continue;
+				if (array_key_exists('ruleImpact', $data)) {
+					$data['ruleScore'] = $data['ruleImpact'] > 0 ? 50 : 100;
+				} else {
+					error_log('Rule score is not specified: '.$rule.' (skipping)');
+					continue;
+				}
 			}
 
 			$value = filter_var($data['ruleScore'], FILTER_VALIDATE_INT);


### PR DESCRIPTION
Greetings!

I was playing around with trying to get the `pagespeed/monitor.sh` script working when I hit the issue that others (https://github.com/sergeychernyshev/showslow/issues/94 and https://github.com/sergeychernyshev/showslow/issues/105 and https://github.com/sergeychernyshev/showslow/issues/112) found when posting the data to `/beacon/pagespeed/`:

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL
server version for the right syntax to use near ')
VALUES (inet_aton('1.2.3.4'), 'curl', '1', '.', '635252', '94.000' at line 5
```

After I [caught up](https://groups.google.com/forum/#!searchin/pagespeed-insights-discuss/showslow/pagespeed-insights-discuss/JJq1i27yUdg/RhbpR5gY384J) on the issue, it seems that this is caused by the PSI service no longer returning `ruleScore` and instead it returns a `ruleImpact`.  This causes none of the rules to match (`Rule score is not specified`), so the `$rules` array is empty, so building the SQL to insert the data fails.

In an attempt to get _some_ data from PSI, I made a small change.  If there is no `ruleScore`, and `ruleImpact` exists, apply some dumb logic to that metric:
* If `ruleImpact` is non-zero, call the score 50% (E)
* If `ruleImpact` is zero, call the score 100%

This at least lets us capture the following data from PSI:

* Page Size
* Total Requests
* Overall Grade
* 6 Pass/Fail rules

![image](https://cloud.githubusercontent.com/assets/1004649/21913809/ccfe33f2-d8fc-11e6-87b6-227ee53b8036.png)

Obviously it's missing a lot of the other metrics, but I feel that something is better than nothing here.

One other idea I had to be smarter about how to convert a `ruleImpact` to a `ruleScore` was to sum all of the `ruleImpact`s, and apply a grade based on each impact vs the sum.  But that felt hard to justify (if a new failure came in, all of your old scores would change?) , so I just left it at the dumb `>0.0 = E` score.